### PR TITLE
Fix clone message for correct payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-py"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "iggy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-py"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Dario Lencina Talarico <darioalessandrolencina@gmail.com>"]
 
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.22.0"
-iggy = "0.4.3"
+iggy = "0.4.3"  
 tokio = { version = "1", features = ["full"] }
 bytes = "1.5"
 openssl = { version = "0.10.*", features = ["vendored"] }

--- a/src/send_message.rs
+++ b/src/send_message.rs
@@ -18,7 +18,7 @@ pub struct SendMessage {
 impl Clone for SendMessage {
     fn clone(&self) -> Self {
         Self {
-            inner: RustSendMessage::from_str(&self.inner.to_string()).unwrap(),
+            inner: self.inner.clone(),
         }
     }
 }


### PR DESCRIPTION
This was adding a weird prefix to the message when sending.

Closes #13 